### PR TITLE
Fix: image shortcode sizing

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -11,7 +11,7 @@ section {
 }
 
 article {
-  @apply prose prose-neutral lg:prose-lg font-inter prose-headings:font-geist prose-a:text-red-700 prose-img:mx-auto prose-img:rounded-lg prose-img:shadow-md mx-auto w-full max-w-prose marker:text-red-700 [&>*:first-child]:mt-0;
+  @apply prose prose-neutral lg:prose-lg font-inter prose-headings:font-geist prose-a:text-red-700 prose-img:mx-auto prose-img:rounded-lg mx-auto w-full max-w-prose marker:text-red-700 [&>*:first-child]:mt-0;
 }
 
 article .footnote-ref {

--- a/layouts/_shortcodes/img.html
+++ b/layouts/_shortcodes/img.html
@@ -4,7 +4,7 @@
   <img
     src="{{ .Get "src" }}"
     alt="{{ .Get "alt" }}"
-    class="block h-auto w-auto rounded-lg"
+    class="{{ .Get "class" }} block h-auto w-auto rounded-lg"
     loading="lazy"
   />
   {{ with .Get "caption" }}

--- a/layouts/_shortcodes/img.html
+++ b/layouts/_shortcodes/img.html
@@ -4,7 +4,7 @@
   <img
     src="{{ .Get "src" }}"
     alt="{{ .Get "alt" }}"
-    class="block h-auto w-auto rounded-lg shadow-md"
+    class="block h-auto w-auto rounded-lg"
     loading="lazy"
   />
   {{ with .Get "caption" }}

--- a/layouts/_shortcodes/img.html
+++ b/layouts/_shortcodes/img.html
@@ -4,7 +4,7 @@
   <img
     src="{{ .Get "src" }}"
     alt="{{ .Get "alt" }}"
-    class="block h-auto w-full max-w-full rounded-lg shadow-md"
+    class="block h-auto w-auto rounded-lg shadow-md"
     loading="lazy"
   />
   {{ with .Get "caption" }}


### PR DESCRIPTION
- Remove `img` shortcode size class
- Remove `img` shortcode and prose image shadow. This allows image with transparent background appear seamless
- Add custom class parameter for `img` shortcode to fine-tune its size and properties